### PR TITLE
fix: python version updated in code-cov and unit-test workflows

### DIFF
--- a/.github/workflows/code_cov.yml
+++ b/.github/workflows/code_cov.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Install Python 3.9.7
+    - name: Install Python 3.12.0
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9.7
+        python-version: 3.12.0
     - name: Install dependencies
       run: |
         pip install pytest-cov

--- a/.github/workflows/code_cov.yml
+++ b/.github/workflows/code_cov.yml
@@ -22,6 +22,16 @@ jobs:
         pip install pytest-cov
         pip install -r requirements.txt
         echo requirements installed
+    - name: 'Create env file'
+      run: |
+        touch .env
+        echo MONGO_URI=${{ secrets.MONGO_URI }} >> .env
+        echo MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} >> .env
+        echo MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} >> .env
+        echo MAIL_SERVER=${{ secrets.MAIL_SERVER }} >> .env
+        echo MAIL_PORT=${{ secrets.MAIL_PORT }} >> .env
+        echo SECRET_KEY=${{ secrets.SECRET_KEY }} >> .env
+        cat .env
     - name: Run the tests
       run: |
         cd src

--- a/.github/workflows/code_cov.yml
+++ b/.github/workflows/code_cov.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install Python 3.11.5
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.11.5
     - name: Install dependencies

--- a/.github/workflows/code_cov.yml
+++ b/.github/workflows/code_cov.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-    - name: Install Python 3.12.0
+    - name: Install Python 3.11.5
       uses: actions/setup-python@v1
       with:
-        python-version: 3.12.0
+        python-version: 3.11.5
     - name: Install dependencies
       run: |
         pip install pytest-cov

--- a/.github/workflows/code_cov.yml
+++ b/.github/workflows/code_cov.yml
@@ -27,7 +27,7 @@ jobs:
         cd src
         python application.py &
         sleep 5
-        cd ../test
+        cd test
         pytest --cov=./
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/code_cov.yml
+++ b/.github/workflows/code_cov.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Run the tests
       run: |
         cd src
-        python app.py &
+        python application.py &
         sleep 5
         cd ../test
         pytest --cov=./

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Test with pytest
       run: |
         cd src
-        python app.py &
+        python application.py &
         sleep 5
         cd ..
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,16 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: 'Create env file'
+      run: |
+        touch .env
+        echo MONGO_URI=${{ secrets.MONGO_URI }} >> .env
+        echo MAIL_USERNAME=${{ secrets.MAIL_USERNAME }} >> .env
+        echo MAIL_PASSWORD=${{ secrets.MAIL_PASSWORD }} >> .env
+        echo MAIL_SERVER=${{ secrets.MAIL_SERVER }} >> .env
+        echo MAIL_PORT=${{ secrets.MAIL_PORT }} >> .env
+        echo SECRET_KEY=${{ secrets.SECRET_KEY }} >> .env
+        cat .env
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/syntax_checker.yml
+++ b/.github/workflows/syntax_checker.yml
@@ -4,5 +4,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: cclauss/Find-Python-syntax-errors-action@master

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Python 3.12.0
+      - name: Install Python 3.11.5
         uses: actions/setup-python@v1
         with:
-          python-version: 3.12.0
+          python-version: 3.11.5
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install Python 3.9.7
+      - name: Install Python 3.12.0
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9.7
+          python-version: 3.12.0
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,5 +22,5 @@ jobs:
           echo requirements installed
       - name: Run tests
         run: |
-          cd test
+          cd src/test
           python -m unittest test

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -11,9 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Python 3.11.5
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11.5
       - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 bcrypt==3.2.0
 blinker==1.4
-bson==0.5.10
+# bson==0.5.10
 certifi==1.0.1
 cffi
 click==8.0.1
@@ -19,7 +19,7 @@ Jinja2==3.0.1
 jwt==1.2.0
 MarkupSafe==2.0.1
 pycparser==2.20
-pymongo==3.11.3
+pymongo==4.5.0
 python-dateutil==2.8.2
 six==1.16.0
 Werkzeug==2.0.1


### PR DESCRIPTION
### Problem:
Previously, python version 3.9.7 was being used for code-coverage and unit testing in git workflows. However, that version is outdated and was not available to use anymore. 

### Solution:
Updated the python version with current latest version 3.12.0.